### PR TITLE
fix: Update CI workflow to use specific commit SHA for job definitions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,48 +12,23 @@ permissions:
 
 jobs:
   bot:
-    uses: anselmes/cicd/.github/workflows/bot.yml@main # main https://github.com/anselmes/cicd/commit/main
+    uses: anselmes/cicd/.github/workflows/bot.yml@042c5469e6121d8aa7578e177c58e12deebff9e1 # v0.2.1
     permissions:
+      contents: write
       issues: write
       pull-requests: write
       repository-projects: write
 
   trivy:
-    uses: anselmes/cicd/.github/workflows/trivy.yml@main # main https://github.com/anselmes/cicd/commit/main
+    uses: anselmes/cicd/.github/workflows/trivy.yml@042c5469e6121d8aa7578e177c58e12deebff9e1 # v0.2.1
     permissions:
-      actions: read
-      attestations: read
-      checks: read
       contents: write
-      deployments: read
-      discussions: read
       id-token: write
-      issues: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
       security-events: write
-      statuses: read
 
   scorecard:
-    uses: anselmes/cicd/.github/workflows/scorecard.yml@main # main https://github.com/anselmes/cicd/commit/main
+    uses: anselmes/cicd/.github/workflows/scorecard.yml@042c5469e6121d8aa7578e177c58e12deebff9e1 # v0.2.1
     permissions:
-      actions: read
-      attestations: read
-      checks: read
       contents: read
-      deployments: read
-      discussions: read
       id-token: write
-      issues: read
-      models: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
       security-events: write
-      statuses: read
-
-  # sonarqube:
-  #   uses: anselmes/cicd/.github/workflows/sonarqube.yml@main # main https://github.com/anselmes/cicd/commit/main

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,14 +18,14 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - hadolint@2.12.1-beta
-    - pre-commit-hooks@5.0.0
     - actionlint@1.7.7
     - checkov@3.2.447
     - dotenv-linter@3.3.0
     - git-diff-check
     - gitleaks@8.27.2
+    - hadolint@2.12.1-beta
     - markdownlint@0.45.0
+    - pre-commit-hooks@5.0.0
     - prettier@3.6.2
     - shellcheck@0.10.0
     - shfmt@3.6.0


### PR DESCRIPTION
# Pull Request
This pull request updates workflow configurations and linter settings to improve CI/CD processes and maintain consistency. Key changes include pinning workflow dependencies to specific versions, modifying permissions for workflows, and reordering linter configurations.

### Workflow configuration updates:
* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L15-L59): Updated the workflow references (`bot`, `trivy`, and `scorecard`) to use a specific version (`v0.2.1`) instead of the `main` branch, ensuring stability and repeatability. Adjusted permissions for workflows, including adding `contents: write` and removing unnecessary read permissions for `trivy` and `scorecard`.

### Linter configuration updates:
* [`.trunk/trunk.yaml`](diffhunk://#diff-45a5a35dd7ad9a52d0fd3540f6c0d16a763575de51cc9a0a6c6f6a9f1da62ecdL21-R28): Reordered the `hadolint` and `pre-commit-hooks` linters within the `enabled` list for better organization, without changing their versions.
